### PR TITLE
fix: update income tax computation to use TRAIN law computation

### DIFF
--- a/src/utils/taxCalculator.ts
+++ b/src/utils/taxCalculator.ts
@@ -1,13 +1,13 @@
 import { TaxBracket, ContributionRates, TaxCalculation } from '../types/tax';
 
-// 2025 Philippines Tax Brackets (BIR)
+// 2025 TRAIN Tax Brackets
 export const TAX_BRACKETS: TaxBracket[] = [
-  { min: 0, max: 250000, rate: 0, baseAmount: 0 },
-  { min: 250000, max: 400000, rate: 0.20, baseAmount: 0 },
-  { min: 400000, max: 800000, rate: 0.25, baseAmount: 30000 },
-  { min: 800000, max: 2000000, rate: 0.30, baseAmount: 130000 },
-  { min: 2000000, max: 8000000, rate: 0.32, baseAmount: 490000 },
-  { min: 8000000, max: Infinity, rate: 0.35, baseAmount: 2410000 }
+  { min: 0, max: 250000, rate: 0.00, baseAmount: 0 },
+  { min: 250000, max: 400000, rate: 0.15, baseAmount: 0 },
+  { min: 400000, max: 800000, rate: 0.20, baseAmount: 22500 },
+  { min: 800000, max: 2000000, rate: 0.25, baseAmount: 102500 },
+  { min: 2000000, max: 8000000, rate: 0.30, baseAmount: 402500 },
+  { min: 8000000, max: Infinity, rate: 0.35, baseAmount: 2202500 }
 ];
 
 // 2025 Contribution Rates
@@ -27,7 +27,7 @@ export const CONTRIBUTION_RATES: ContributionRates = {
     lowRate: 0.01, // 1%
     highRate: 0.02, // 2%
     threshold: 1500,
-    maxContribution: 300
+    maxContribution: 200
   }
 };
 
@@ -37,8 +37,10 @@ export function calculateSSS(monthlySalary: number): number {
 }
 
 export function calculatePhilHealth(monthlySalary: number): number {
-  const premium = monthlySalary * (CONTRIBUTION_RATES.philHealth.rate / 2); // Employee portion only
-  return Math.min(Math.max(premium, CONTRIBUTION_RATES.philHealth.minPremium / 2), CONTRIBUTION_RATES.philHealth.maxPremium / 2);
+  const incomeCeiling = 100000; // DOH/BIR-mandated ceiling
+  const cappedSalary = Math.min(monthlySalary, incomeCeiling);
+  const employeeShare = (CONTRIBUTION_RATES.philHealth.rate / 2);
+  return cappedSalary * employeeShare;
 }
 
 export function calculatePagibig(monthlySalary: number): number {


### PR DESCRIPTION
Changes includes adhering to the new Tax Rate as implemented via TRAIN Law. Observe the tax table below:

| Income Range (Annual)      | Pre-TRAIN Law Tax Rates                                  | TRAIN Law Tax Rates (2025)                                   |
|---------------------------|----------------------------------------------------------|--------------------------------------------------------------|
| ₱0 – ₱250,000             | 5% of gross income (minimum tax)                         | 0% (Exempted — no income tax on first ₱250,000)              |
| ₱250,001 – ₱400,000       | ₱12,500 + 20% of excess over ₱250,000                    | 15% of excess over ₱250,000                                   |
| ₱400,001 – ₱800,000       | ₱37,500 + 25% of excess over ₱400,000                    | ₱22,500 + 20% of excess over ₱400,000                         |
| ₱800,001 – ₱2,000,000     | ₱137,500 + 30% of excess over ₱800,000                   | ₱102,500 + 25% of excess over ₱800,000                        |
| ₱2,000,001 – ₱8,000,000   | ₱437,500 + 32% of excess over ₱2,000,000                 | ₱402,500 + 30% of excess over ₱2,000,000                      |
| Above ₱8,000,000          | ₱2,417,500 + 35% of excess over ₱8,000,000               | ₱2,202,500 + 35% of excess over ₱8,000,000                    |

---

This change also includes the **new** Pag-IBIG max contribution.

Before the 2024 update (and even for several years), the Pag-IBIG employee contribution max was generally ₱100 to ₱300, depending on which version or rule was referenced.

Many private companies voluntarily contributed 2% of salary but capped contributions at ₱300, which became a common "unofficial max" many calculators used.

As of early 2024 (Pag-IBIG Circular No. 460), mandatory contributions were standardized at:

- **2% of monthly salary (employee share) capped at ₱200**
- **2% of monthly salary (employer share) capped at ₱200**
- **Total capped at ₱400 combined**

The salary ceiling for Pag-IBIG contribution base was set at **₱10,000** (up from ₱5,000), which means:

- 2% of ₱10,000 = **₱200 max contribution**


---

For reference, other tax calculators are now also using the TRAIN Law computation:

* https://sprout.ph/tax-calculator-philippines/
* https://taxcalculatorphilippines.com/