### PR TITLE
chore: lint and build checks only for pull request

### DIFF
--- a/.github/workflows/azure-static-web-apps-proud-mushroom-082b95e1e.yml
+++ b/.github/workflows/azure-static-web-apps-proud-mushroom-082b95e1e.yml
@@ -10,8 +10,29 @@ on:
       - main
 
 jobs:
+  lint_and_build_job:
+    if: github.event_name == 'pull_request' && github.event.action != 'closed'
+    runs-on: ubuntu-latest
+    name: Lint and Build Job
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: true
+          lfs: false
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '22'
+          cache: 'npm'
+      - name: Install dependencies
+        run: npm ci
+      - name: Run lint
+        run: npm run lint
+      - name: Run build
+        run: npm run build
+
   build_and_deploy_job:
-    if: github.event_name == 'push' || (github.event_name == 'pull_request' && github.event.action != 'closed')
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     name: Build and Deploy Job
     steps:


### PR DESCRIPTION
Github Workflow for Deployment Updates:

1. New lint_and_build_job - Runs only for pull requests and executes:
    - npm run lint to check code quality
    - npm run build to verify the project builds successfully
 
2. Modified build_and_deploy_job - Now only runs on pushes to main branch (actualdeployment)
 
This ensures that pull requests are validated with lint and build checks without triggering actual deployment to Azure Static Web Apps.

Closes: https://github.com/bettergovph/ph-tax-directory/issues/4